### PR TITLE
Update pdfjs-init.js to match other Hypothesis apps

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "arrowParens": "avoid",
+  "singleQuote": true
+}

--- a/pdfjs-init.js
+++ b/pdfjs-init.js
@@ -1,7 +1,7 @@
 'use strict';
 
-// nb. After making changes to this file, the copy in the viewer/web/ dir
-// must be updated.
+// Script that loads the Hypothesis client after PDF.js is initialized.
+// After making changes to this file, copy it to viewer/web/pdfjs-init.js.
 
 // Listen for `webviewerloaded` event to configure the viewer after its files
 // have been loaded but before it is initialized.
@@ -17,7 +17,6 @@ try {
 }
 
 function onViewerLoaded() {
-  // Wait for the PDF viewer to be fully initialized and then load the Hypothesis client.
   PDFViewerApplication.initializedPromise.then(() => {
     const embedScript = document.createElement('script');
     embedScript.src = 'https://hypothes.is/embed.js';

--- a/pdfjs-init.js
+++ b/pdfjs-init.js
@@ -1,59 +1,26 @@
 'use strict';
 
-// Note: This file is not transpiled. For IE 11 compatibility, it must only
-// use ES5 language features.
-//
-// This script can however assume that some ES2015+ library features, eg.
-// Promises, will already have been polyfilled as PDF.js uses them.
+// nb. After making changes to this file, the copy in the viewer/web/ dir
+// must be updated.
 
 // Listen for `webviewerloaded` event to configure the viewer after its files
 // have been loaded but before it is initialized.
-document.addEventListener('webviewerloaded', function(event) {
-  var appOptions = window.PDFViewerApplicationOptions;
-  var app = window.PDFViewerApplication;
+//
+// PDF.js >= v2.10.377 fires this event at the parent document if it is embedded
+// in a same-origin iframe. See https://github.com/mozilla/pdf.js/pull/11837.
+try {
+  parent.document.addEventListener('webviewerloaded', onViewerLoaded);
+} catch (err) {
+  // Parent document is cross-origin. The event will be fired at the current
+  // document instead.
+  document.addEventListener('webviewerloaded', onViewerLoaded);
+}
 
-  // Ensure that PDF.js viewer events such as "documentloaded" are dispatched
-  // to the DOM. The client relies on this.
-  appOptions.set('eventBusDispatchToDOM', true);
-
-  // Disable preferences support, as otherwise this will result in `eventBusDispatchToDOM`
-  // being overridden with the default value of `false`.
-  appOptions.set('disablePreferences', true);
-
+function onViewerLoaded() {
   // Wait for the PDF viewer to be fully initialized and then load the Hypothesis client.
-  //
-  // This is required because the client currently assumes that `PDFViewerApplication`
-  // is fully initialized when it loads. Note that "fully initialized" only means
-  // that the PDF viewer application's components have been initialized. The
-  // PDF itself will still be loading, and the client will wait for that to
-  // complete before fetching annotations.
-  //
-  var pdfjsInitialized = new Promise(function (resolve) {
-    // Poll `app.initialized` as there doesn't appear to be an event that
-    // we can listen to.
-    var timer = setInterval(function () {
-      if (app.initialized) {
-        clearTimeout(timer);
-        resolve();
-      }
-    }, 20);
-  });
-
-  pdfjsInitialized.then(function () {
-    // Prevent PDF.js' `Promise` polyfill, if it was used, from being
-    // overwritten by the one that ships with Hypothesis (both from core-js).
-    //
-    // See https://github.com/hypothesis/via/issues/81#issuecomment-531121534
-    if (typeof Promise === 'function' && typeof PromiseRejectionEvent === 'undefined') {
-      window.PromiseRejectionEvent = function FakePromiseRejectionEvent(type, options) {
-        // core-js doesn't actually use this, it just tests for `typeof PromiseRejectionEvent`
-        console.warn('Tried to construct fake `PromiseRejectionEvent`');
-      };
-    }
-
-    // Load the Hypothesis client.
-    var embedScript = document.createElement('script');
+  PDFViewerApplication.initializedPromise.then(() => {
+    const embedScript = document.createElement('script');
     embedScript.src = 'https://hypothes.is/embed.js';
     document.body.appendChild(embedScript);
   });
-});
+}

--- a/viewer/web/pdfjs-init.js
+++ b/viewer/web/pdfjs-init.js
@@ -1,59 +1,26 @@
 'use strict';
 
-// Note: This file is not transpiled. For IE 11 compatibility, it must only
-// use ES5 language features.
-//
-// This script can however assume that some ES2015+ library features, eg.
-// Promises, will already have been polyfilled as PDF.js uses them.
+// nb. After making changes to this file, the copy in the viewer/web/ dir
+// must be updated.
 
 // Listen for `webviewerloaded` event to configure the viewer after its files
 // have been loaded but before it is initialized.
-document.addEventListener('webviewerloaded', function(event) {
-  var appOptions = window.PDFViewerApplicationOptions;
-  var app = window.PDFViewerApplication;
+//
+// PDF.js >= v2.10.377 fires this event at the parent document if it is embedded
+// in a same-origin iframe. See https://github.com/mozilla/pdf.js/pull/11837.
+try {
+  parent.document.addEventListener('webviewerloaded', onViewerLoaded);
+} catch (err) {
+  // Parent document is cross-origin. The event will be fired at the current
+  // document instead.
+  document.addEventListener('webviewerloaded', onViewerLoaded);
+}
 
-  // Ensure that PDF.js viewer events such as "documentloaded" are dispatched
-  // to the DOM. The client relies on this.
-  appOptions.set('eventBusDispatchToDOM', true);
-
-  // Disable preferences support, as otherwise this will result in `eventBusDispatchToDOM`
-  // being overridden with the default value of `false`.
-  appOptions.set('disablePreferences', true);
-
+function onViewerLoaded() {
   // Wait for the PDF viewer to be fully initialized and then load the Hypothesis client.
-  //
-  // This is required because the client currently assumes that `PDFViewerApplication`
-  // is fully initialized when it loads. Note that "fully initialized" only means
-  // that the PDF viewer application's components have been initialized. The
-  // PDF itself will still be loading, and the client will wait for that to
-  // complete before fetching annotations.
-  //
-  var pdfjsInitialized = new Promise(function (resolve) {
-    // Poll `app.initialized` as there doesn't appear to be an event that
-    // we can listen to.
-    var timer = setInterval(function () {
-      if (app.initialized) {
-        clearTimeout(timer);
-        resolve();
-      }
-    }, 20);
-  });
-
-  pdfjsInitialized.then(function () {
-    // Prevent PDF.js' `Promise` polyfill, if it was used, from being
-    // overwritten by the one that ships with Hypothesis (both from core-js).
-    //
-    // See https://github.com/hypothesis/via/issues/81#issuecomment-531121534
-    if (typeof Promise === 'function' && typeof PromiseRejectionEvent === 'undefined') {
-      window.PromiseRejectionEvent = function FakePromiseRejectionEvent(type, options) {
-        // core-js doesn't actually use this, it just tests for `typeof PromiseRejectionEvent`
-        console.warn('Tried to construct fake `PromiseRejectionEvent`');
-      };
-    }
-
-    // Load the Hypothesis client.
-    var embedScript = document.createElement('script');
+  PDFViewerApplication.initializedPromise.then(() => {
+    const embedScript = document.createElement('script');
     embedScript.src = 'https://hypothes.is/embed.js';
     document.body.appendChild(embedScript);
   });
-});
+}


### PR DESCRIPTION
Update the script that loads the Hypothesis client to match recent changes to the corresponding script in Via [1] and the browser extension. This resolves an issue when PDF.js is loaded inside a same-origin iframe and removes obsolete code for IE 11 compatibility.

This PR includes updates to two copies of `pdfjs-init.js`. The one in the root of the repo is the source file, the one in `viewer/web/` is a copy of it, which is normally update by the `tools/update-pdfjs` script.

Fixes #22

[1] https://github.com/hypothesis/via/blob/0fef53e973215907b5fa4b429b3eae3002593489/via/static/js/pdfjs-init.js

---

**Testing:**

1. Check out this branch and run `python -m http.server 8005`
2. Go to `http://localhost:8005/` and check that the viewer loads with the client embedded
3. Save the code below as `iframe-test.html`, then visit http://localhost:8005/iframe-test.html and check that the client loads

```html
<html>
  <body>
    <iframe width="800" height="800" src="viewer/web/viewer.html">
  </body>
</html>
```